### PR TITLE
Uses fork of travis dpl to detect wasm mime-type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ deploy:
   secret_access_key: $AWS_SECRET_KEY
   region: $AWS_DEFAULT_REGION
   cache_control: "max-age=31536000"
+  detect_encoding: true
   on:
     branch:
       - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ deploy:
   on:
     branch:
       - master
+      - deploy-test3
     
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ deploy:
   provider: s3
   edge:
     source: jonstites/dpl
-    branch: feature/mime-types-3
+    branch: feature/upgrade-mime-types-gem
   bucket: life.jonstites.com  
   skip_cleanup: true
   local_dir: www/dist
@@ -59,7 +59,6 @@ deploy:
   on:
     branch:
       - master
-      - deploy-test3
     
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ before_deploy:
   
 deploy:
   provider: s3
+  edge:
+    source: jonstites/dpl
+    branch: feature/mime-types-3
   bucket: life.jonstites.com  
   skip_cleanup: true
   local_dir: www/dist


### PR DESCRIPTION
Currently travis's dpl tool uses version 2 of the mime-type Ruby gem. Current version 3 auto-detects webassembly mime-type, so I forked dpl and bumped up the mime-type gem version.